### PR TITLE
 `SimpleSemaphorePaymaster` deploy script and Update OpenZeppelin contracts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ contracts/deployedAddresses.json
 
 .vscode
 .idea
+
+bun.lock

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@account-abstraction": "https://github.com/eth-infinitism/account-abstraction",
     "@excubiae/contracts": "^0.10.0",
-    "@openzeppelin/contracts": "^5.0.2",
+    "@openzeppelin/contracts": "^5.1.0",
     "@openzeppelin/contracts-upgradeable": "^5.0.0",
     "@semaphore-protocol/contracts": "4.8.2",
     "@semaphore-protocol/group": "^4.8.2",

--- a/contracts/script/DeploySimpleSemaphorePaymaster.sol
+++ b/contracts/script/DeploySimpleSemaphorePaymaster.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Script} from "forge-std/Script.sol";
+import {SimpleSemaphorePaymaster} from "../src/SimpleSemaphorePaymaster.sol";
+import {console} from "forge-std/console.sol";
+
+contract DeploySimpleSemaphorePaymaster is Script {
+    address verifier = 0x6C42599435B82121794D835263C846384869502d; // base sepolia
+    address entryPoint = 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789;
+
+    function run() external returns (SimpleSemaphorePaymaster) {
+        // Begin sending transactions
+        vm.startBroadcast();
+
+        // Deploy the contract
+        SimpleSemaphorePaymaster paymaster = new SimpleSemaphorePaymaster(entryPoint, verifier);
+        paymaster.addStake{value: 1000000000000000000}(1);
+
+        // Stop broadcasting transactions
+        vm.stopBroadcast();
+
+        // Log the deployment address
+        console.log("SimpleSemaphorePaymaster deployed at:", address(paymaster));
+
+        return paymaster;
+    }
+}

--- a/contracts/src/mocks/SimpleAccount.sol
+++ b/contracts/src/mocks/SimpleAccount.sol
@@ -33,7 +33,7 @@ contract SimpleAccount is BaseAccount {
     /// @param dest The destination address
     /// @param value The amount of ETH to send
     /// @param func The function data to execute
-    function execute(address dest, uint256 value, bytes calldata func) external override {
+    function execute(address dest, uint256 value, bytes calldata func) external {
         _requireFromEntryPoint();
         (bool success, bytes memory result) = dest.call{value: value}(func);
         if (!success) {

--- a/contracts/src/mocks/SimpleAccount.sol
+++ b/contracts/src/mocks/SimpleAccount.sol
@@ -33,7 +33,7 @@ contract SimpleAccount is BaseAccount {
     /// @param dest The destination address
     /// @param value The amount of ETH to send
     /// @param func The function data to execute
-    function execute(address dest, uint256 value, bytes calldata func) external {
+    function execute(address dest, uint256 value, bytes calldata func) external override {
         _requireFromEntryPoint();
         (bool success, bytes memory result) = dest.call{value: value}(func);
         if (!success) {

--- a/contracts/yarn.lock
+++ b/contracts/yarn.lock
@@ -743,12 +743,12 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-5.1.0.tgz#4d37648b7402929c53e2ff6e45749ecff91eb2b6"
   integrity sha512-AIElwP5Ck+cslNE+Hkemf5SxjJoF4wBvvjxc27Rp+9jaPs/CLIaUBMYe1FNzhdiN0cYuwGRmYaRHmmntuiju4Q==
 
-"@openzeppelin/contracts@^5.0.0", "@openzeppelin/contracts@^5.0.2":
+"@openzeppelin/contracts@^5.0.0":
   version "5.0.2"
   resolved "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-5.0.2.tgz"
   integrity sha512-ytPc6eLGcHHnapAZ9S+5qsdomhjo6QBHTDRRBFfTxXIpsicMhVPouPgmUPebZZZGX7vt9USA+Z+0M0dSVtSUEA==
 
-"@openzeppelin/contracts@^5.2.0":
+"@openzeppelin/contracts@^5.1.0", "@openzeppelin/contracts@^5.2.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-5.3.0.tgz#0a90ce16f5c855e3c8239691f1722cd4999ae741"
   integrity sha512-zj/KGoW7zxWUE8qOI++rUM18v+VeLTTzKs/DJFkSzHpQFPD/jKKF0TrMxBfGLl3kpdELCNccvB3zmofSzm4nlA==


### PR DESCRIPTION
# `SimpleSemaphorePaymaster` deploy script and Update OpenZeppelin contracts

## Changes

- Update `@openzeppelin/contracts` dependency from ^5.0.2 to ^5.1.0
- Add new deploy script for SimpleSemaphorePaymaster contract
- Add `bun.lock` to .gitignore
- Update yarn.lock dependencies

## Details

The new deployment script sets up the SimpleSemaphorePaymaster contract with the Base Sepolia verifier address and standard EntryPoint contract, including an initial stake of 1 ETH.